### PR TITLE
update installation instructions - GLASS 1.0-beta9.3 and related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
    - ST=GemStone-2.4.5.2
    - ST=GemStone-3.0.1
    - ST=GemStone-3.1.0.6
-   - ST=GemStone-3.2.0
+   - ST=GemStone-3.2.2
 #   - ST=GemStone-2.4.4.1
 #   - ST=GemStone-2.4.4.8
 #   - ST=GemStone-2.4.5

--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
 # GLASS [![Build Status](https://travis-ci.org/glassdb/glass.png?branch=master)](https://travis-ci.org/glassdb/glass)
 
 ## Installation
+In a fresh extent run the following:
 
 ```Smalltalk
-"Upgrade GLASS to to 1.0-beta.9.1"
+"Upgrade GLASS to to 1.0-beta.9.3"
 ConfigurationOfGLASS project updateProject.
 GsDeployer
-  deploy: [ (ConfigurationOfGLASS project version: '1.0-beta.9.1') load ].
-
-"Install Metacello"
-GsDeployer deploy: [
- Metacello new
-  baseline: 'Metacello';
-  repository: 'github://dalehenrich/metacello-work:master/repository';
-  get.
- Metacello new
-  baseline: 'Metacello';
-  repository: 'github://dalehenrich/metacello-work:master/repository';
-  load: 'ALL' ].
-
+  deploy: [ (ConfigurationOfGLASS project version: '1.0-beta.9.3') load ].
 "Install GLASS from github"
 GsDeployer deploy: [
  Metacello new

--- a/tests/travisCI.st
+++ b/tests/travisCI.st
@@ -10,24 +10,27 @@ Transcript cr; show: 'travis---->travisCI.st'.
 gitCache := 'git_cache'.
 gitPath := (FileDirectory default directoryNamed: gitCache ) fullName.
 
-[
 "Load GLASS1.0-beta.9.3 ... should prime things for loading GLASS1"
 ConfigurationOfGLASS project updateProject.
-(ConfigurationOfGLASS project version: '1.0-beta.9.3') load.
+GsDeployer deploy: [
+  (ConfigurationOfGLASS project version: '1.0-beta.9.3') load ].
 
-"Load the GLASS1 baseline"
-Metacello new
-	baseline: 'GLASS1';
-  repository: 'filetree://', gitPath, '/glass/repository';
-  get.
-
-Metacello new
-	baseline: 'GLASS1';
-  repository: 'filetree://', gitPath, '/glass/repository';
-  load: #( 'GLASS').
-] on: Warning do: [:ex | 
-  Transcript cr; show: 'WARNING: ', ex description.
-  ex resume: true ].
+GsDeployer deploy: [
+  "Load the GLASS1 baseline"
+  Metacello new
+    baseline: 'GLASS1';
+    repository: 'filetree://', gitPath, '/glass/repository';
+    get.
+  Metacello new
+    baseline: 'GLASS1';
+    repository: 'filetree://', gitPath, '/glass/repository';
+    onConflict: [ :ex | ex allow ];
+    onWarning: [ :ex | 
+        Transcript
+          cr;
+          show: ex description.
+        ex resume ];
+    load: #( 'default') ].
 
 "Run the GLASS1 tests"
 MetacelloPlatform current authorName: 'testMonkey'. "These tests save code ... need an Author"


### PR DESCRIPTION
travis tests and installation instructions now match add a .gitignore file for good measure and update lineup to use 3.2.2
