### PR TITLE
Proposed fix for issue #106

### DIFF
--- a/repository/Monticello.v3.package/MCPlatformSupport.class/class/redefineSubclassesOf.using..st
+++ b/repository/Monticello.v3.package/MCPlatformSupport.class/class/redefineSubclassesOf.using..st
@@ -3,5 +3,4 @@ redefineSubclassesOf: aClass using: aClassOrganizer
 
 	(aClassOrganizer subclassesOf: aClass) do: [:subClass | | newClass |
 		newClass := subClass definition evaluate.
-		self redefineSubclassesOf: subClass using: aClassOrganizer.
 	].


### PR DESCRIPTION
Issue #106: Eliminate the recursive call, since evaluation of the class definition string already invokes the method for the subclasses hierarchies.